### PR TITLE
fix header auth token functionality

### DIFF
--- a/lib/devise/strategies/access_token_authenticatable.rb
+++ b/lib/devise/strategies/access_token_authenticatable.rb
@@ -36,7 +36,7 @@ module Devise
         body[:error_description] = description if description
 
         headers = {"Content-Type" => "application/json; charset=utf-8"}
-        
+
         custom! [status, headers, [body.to_json]]
       end
 
@@ -56,7 +56,7 @@ module Devise
 
       def access_token_in_header
         auth_header = ::Rack::Auth::AbstractRequest.new(env)
-        if auth_header.provided? && auth_header.scheme == :bearer
+        if auth_header.provided? && auth_header.scheme.to_sym == :bearer
           auth_header.params
         else
           nil


### PR DESCRIPTION
later versions of ruby break the ability to do == comparison of string and symbol.  this prevents header auth working
